### PR TITLE
upgrade to latest rollup and latest dependency versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import { minify } from 'html-minifier';
 
 export default function string(opts = {}) {
 	if (!opts.include) {
-		opts.include = '**/*.html'
+		opts.include = '**/*.html';
 	}
 
 	const filter = createFilter(opts.include, opts.exclude);

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "dist"
   ],
   "dependencies": {
-    "html-minifier": "^3.0.2",
-    "rollup-pluginutils": "^1.5.0"
+    "html-minifier": "^3.5.21",
+    "rollup-pluginutils": "^2.3.3"
   },
   "devDependencies": {
-    "buble": "^0.10.6",
-    "mocha": "^2.5.3",
-    "rollup": "^0.31.2",
-    "rollup-plugin-buble": "^0.10.0"
+    "buble": "^0.19.6",
+    "mocha": "^5.2.0",
+    "rollup": "^0.67.4",
+    "rollup-plugin-buble": "^0.19.6"
   },
   "scripts": {
     "build": "rollup -c",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,17 +4,17 @@ var pkg = require('./package.json');
 var external = Object.keys(pkg.dependencies).concat('path');
 
 export default {
-	entry: 'index.js',
+	input: 'index.js',
 	plugins: [buble()],
 	external: external,
-	targets: [
+	output: [
 		{
 			format: 'cjs',
-			dest: pkg['main']
+			file: pkg['main']
 		},
 		{
-			format: 'es6',
-			dest: pkg['jsnext:main']
+			format: 'es',
+			file: pkg['jsnext:main']
 		}
 	]
 };

--- a/test/index.js
+++ b/test/index.js
@@ -11,25 +11,36 @@ function makeBundle(options, stringOptions) {
 
 describe('rollup-plugin-html', () => {
 	it('should import html from file as string', () => {
-		return makeBundle({ entry: 'fixtures/basic.js' }, { include: '**/*.html' }).then(bundle => {
-			const { code } = bundle.generate({ format: 'iife', moduleName: 'tpl' });
-			new Function('assert', code)(assert);
+		return makeBundle({ input: 'fixtures/basic.js' }, { include: '**/*.html' }).then(bundle => {
+			return bundle.generate({ format: 'iife', moduleName: 'tpl' });
+		}).then(({ code }) => {
+			return new Function('assert', code)(assert);
 		});
 	});
 
 	it('should output empty sourcemap', () => {
-		return makeBundle({ entry: 'fixtures/basic.js' }, { include: '**/*.html' }).then(bundle => {
-			const { code, map } = bundle.generate({ sourceMap: true });
+		return makeBundle({ input: 'fixtures/basic.js' }, { include: '**/*.html' }).then(bundle => {
+			return bundle.generate({ format: 'es', sourcemap: true });
+		}).then(({ code, map }) => {
 			assert.ok(code);
 			assert.ok(map);
 		});
 	});
 
 	it('should import minified html when html-minifier options are present', () => {
-		return makeBundle({ entry: 'fixtures/basic.js' }, { include: '**/*.html', htmlMinifierOptions: { collapseWhitespace: true, collapseBooleanAttributes: true, conservativeCollapse: true, minifyJS: true } }).then(bundle => {
-			const { code, map } = bundle.generate();
+		const htmlMinifierOptions = {
+			collapseWhitespace: true,
+			collapseBooleanAttributes: true,
+			conservativeCollapse: true,
+			minifyJS: true
+		};
+		const htmlOptions = { include: '**/*.html', htmlMinifierOptions };
+
+		return makeBundle({ input: 'fixtures/basic.js' }, htmlOptions).then(bundle => {
+			return bundle.generate({ format: 'iife' });
+		}).then(({ code, map }) => {
 			assert.ok(code);
-			assert.notEqual(code.indexOf(`var tpl = "<h1>This is the Title</h1> <section class=\\"section\\"> <article class=\\"article\\">Article 1</article> <article class=\\"article\\">Article 2</article> </section> <script>!function(){console.log(\\"init\\")}()</script> ";`), -1);
+			assert.notEqual(code.indexOf(`var tpl = "<h1>This is the Title</h1> <section class=\\"section\\"> <article class=\\"article\\">Article 1</article> <article class=\\"article\\">Article 2</article> </section> <script>console.log(\\"init\\")</script> ";`), -1);
 		});
 	});
 });


### PR DESCRIPTION
This just upgrades dependencies to the latest and updates tests to newer rollup config. 

No functional changes to the plugin itself, I was just having some trouble with the version of `rollup-pluginutils` that it depended on.